### PR TITLE
Removes old CLIP dependency that causes Py3.12 to fail installing

### DIFF
--- a/modelvshuman/models/pytorch/model_zoo.py
+++ b/modelvshuman/models/pytorch/model_zoo.py
@@ -484,15 +484,15 @@ def selecsls60b(model_name, *args):
 
 @register_model("pytorch")
 def clip(model_name, *args):
-    import clip
-    model, _ = clip.load("ViT-B/32")
+    import open_clip
+    model, _, _ = open_clip.create_model_and_transforms('ViT-B-32', pretrained='openai')
     return ClipPytorchModel(model, model_name, *args)
 
 
 @register_model("pytorch")
 def clipRN50(model_name, *args):
-    import clip
-    model, _ = clip.load("RN50")
+    import open_clip
+    model, _, _ = open_clip.create_model_and_transforms('RN50', pretrained='openai')
     return ClipPytorchModel(model, model_name, *args)
 
 

--- a/modelvshuman/models/wrappers/pytorch.py
+++ b/modelvshuman/models/wrappers/pytorch.py
@@ -1,6 +1,6 @@
 import math
 import PIL
-import clip
+import open_clip
 import numpy as np
 import torch
 from PIL.Image import Image
@@ -117,7 +117,7 @@ class ClipPytorchModel(PytorchModel):
             zeroshot_weights = []
             for class_name in tqdm(class_names):
                 texts = [template.format(class_name) for template in templates]  # format with class
-                texts = clip.tokenize(texts).to(device())  # tokenize
+                texts = open_clip.tokenize(texts).to(device())  # tokenize
                 class_embeddings = self.model.encode_text(texts)  # embed with text encoder
                 class_embeddings /= class_embeddings.norm(dim=-1, keepdim=True)
                 class_embedding = class_embeddings.mean(dim=0)
@@ -128,7 +128,8 @@ class ClipPytorchModel(PytorchModel):
         return zeroshot_weights
 
     def preprocess(self):
-        n_px = self.model.visual.input_resolution
+        # open-clip uses image_size (a tuple) instead of input_resolution (an int)
+        n_px = self.model.visual.image_size[0] if isinstance(self.model.visual.image_size, tuple) else self.model.visual.image_size
         return Compose([
             Resize(n_px, interpolation=PIL.Image.BICUBIC),
             CenterCrop(n_px),

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,6 +34,7 @@ setup_requires =
     # setuptools >=30.3.0     # minimal version for `setup.cfg`
     # setuptools >=38.3.0     # version with most `setup.cfg` bugfixes
 install_requires =
+    setuptools<70
     torch>=1.7.1
     torchvision>=0.8.2
     requests
@@ -50,7 +51,7 @@ install_requires =
     ftfy
     regex
     tqdm
-    CLIP @ git+https://github.com/openai/CLIP#egg=CLIP
+    open-clip-torch
     pytorch_pretrained_vit
     tensorflow-estimator
     numexpr>=2.7.3


### PR DESCRIPTION
This PR updates the dependencies to make sure the package can be installed in recent Python versions which deprecate certain build processes. The CLIP dependency has been replaced with an open source implementation that has feature and API parity.